### PR TITLE
Fixed the vehicle inventory bug

### DIFF
--- a/common/src/main/java/immersive_aircraft/entity/InventoryVehicleEntity.java
+++ b/common/src/main/java/immersive_aircraft/entity/InventoryVehicleEntity.java
@@ -121,11 +121,9 @@ public abstract class InventoryVehicleEntity extends VehicleEntity implements Co
         return new VehicleScreenHandler(i, playerInventory, this);
     }
 
-    protected int syncId;
-
     public void openInventory(ServerPlayer player) {
-        syncId = (syncId + 1) % 100 + 100;
-        AbstractContainerMenu screenHandler = createMenu(syncId, player.getInventory(), player);
+        player.nextContainerCounter();
+        AbstractContainerMenu screenHandler = createMenu(player.containerCounter, player.getInventory(), player);
         if (screenHandler != null) {
             NetworkHandler.sendToPlayer(new OpenGuiRequest(this, screenHandler.containerId), player);
             player.containerMenu = screenHandler;

--- a/common/src/main/resources/immersive_aircraft.accessWidener
+++ b/common/src/main/resources/immersive_aircraft.accessWidener
@@ -1,1 +1,3 @@
 accessWidener	v1	named
+accessible field net/minecraft/server/level/ServerPlayer containerCounter I
+accessible method net/minecraft/server/level/ServerPlayer nextContainerCounter ()V


### PR DESCRIPTION
Fixed #80 by using the `ServerPlayer.containerCounter` instead of a custom `syncId` variable. As far as I can understand - the container counter is intended to be in the range between 1 and 100. Previously, syncId would start at 101 and increase indefinitely, which broke synchronization when playing in multiplayer after reaching a certain number (I think it was 128).

This also could've been fixed by altering the `syncId` generation logic, but using `ServerPlayer.containerCounter` via the Access Widener seems like the most proper solution here.