### PR TITLE
Apply Ad Astra's Gravity API

### DIFF
--- a/common/src/main/java/immersive_aircraft/CompatUtil.java
+++ b/common/src/main/java/immersive_aircraft/CompatUtil.java
@@ -1,0 +1,10 @@
+package immersive_aircraft;
+
+import dev.architectury.injectables.annotations.ExpectPlatform;
+
+public class CompatUtil {
+    @ExpectPlatform
+    public static boolean isModLoaded(String modid) {
+        throw new AssertionError();
+    }
+}

--- a/common/src/main/java/immersive_aircraft/entity/VehicleEntity.java
+++ b/common/src/main/java/immersive_aircraft/entity/VehicleEntity.java
@@ -2,6 +2,8 @@ package immersive_aircraft.entity;
 
 import com.google.common.collect.Lists;
 import com.mojang.math.Axis;
+import earth.terrarium.adastra.api.systems.GravityApi;
+import immersive_aircraft.CompatUtil;
 import immersive_aircraft.Main;
 import immersive_aircraft.Sounds;
 import immersive_aircraft.client.KeyBindings;
@@ -529,7 +531,7 @@ public abstract class VehicleEntity extends Entity {
     protected abstract void updateVelocity();
 
     protected float getGravity() {
-        return -0.04f;// * GravityApi.API.getGravity(level(), BlockPos.containing(getEyePosition()));
+        return -0.04f * (CompatUtil.isModLoaded("ad_astra") ? GravityApi.API.getGravity(level(), BlockPos.containing(getEyePosition())) : 1);
     }
 
     protected abstract void updateController();

--- a/fabric/src/main/java/immersive_aircraft/fabric/CompatUtilImpl.java
+++ b/fabric/src/main/java/immersive_aircraft/fabric/CompatUtilImpl.java
@@ -1,0 +1,9 @@
+package immersive_aircraft.fabric;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+public class CompatUtilImpl {
+    public static boolean isModLoaded(String modid) {
+        return FabricLoader.getInstance().isModLoaded(modid);
+    }
+}

--- a/forge/src/main/java/immersive_aircraft/forge/CompatUtilImpl.java
+++ b/forge/src/main/java/immersive_aircraft/forge/CompatUtilImpl.java
@@ -1,0 +1,9 @@
+package immersive_aircraft.forge;
+
+import net.minecraftforge.fml.ModList;
+
+public class CompatUtilImpl {
+    public static boolean isModLoaded(String modid) {
+        return ModList.get().isLoaded(modid);
+    }
+}


### PR DESCRIPTION
Since this mod doesn't depend on the Architectury API I wrote a custom little thing to check if a mod is loaded. I'm using that to only access Ad Astra's Gravity API if the mod is loaded, hence preventing classloading errors.