### PR TITLE
Collision Damage Multiplier config

### DIFF
--- a/common/src/main/java/immersive_aircraft/config/Config.java
+++ b/common/src/main/java/immersive_aircraft/config/Config.java
@@ -84,6 +84,9 @@ public final class Config extends JsonConfig {
     @BooleanConfigEntry(true)
     public boolean collisionDamage;
 
+    @FloatConfigEntry(40.0f)
+    public float collisionDamageMultiplier;
+
     @BooleanConfigEntry(false)
     public boolean burnFuelInCreative;
 

--- a/common/src/main/java/immersive_aircraft/entity/VehicleEntity.java
+++ b/common/src/main/java/immersive_aircraft/entity/VehicleEntity.java
@@ -745,7 +745,7 @@ public abstract class VehicleEntity extends Entity {
                 if (collision > 0) {
                     float repeat = 1.0f - (getDamageWobbleTicks() + 1) / 10.0f;
                     if (repeat > 0.0001f) {
-                        float damage = collision * 40 * repeat * repeat;
+                        float damage = collision * Config.getInstance().collisionDamageMultiplier * repeat * repeat;
                         NetworkHandler.sendToServer(new CollisionMessage(damage));
                     }
                 }


### PR DESCRIPTION
Adds a new config: collisionDamageMultiplier (defaults to 40), to adjust how much damage do aircraft take when colliding, especifically.

On a modpack I am making, I wanted to make planes a bit more fragile towards collisions, but without making them made of paper when it comes to other sources of damage.