### PR TITLE
Fix hotbar overlay still rendering even when the hotbar is set to not render

### DIFF
--- a/neoforge/src/main/java/immersive_aircraft/neoforge/NeoForgeOverlayRenderer.java
+++ b/neoforge/src/main/java/immersive_aircraft/neoforge/NeoForgeOverlayRenderer.java
@@ -2,20 +2,19 @@ package immersive_aircraft.neoforge;
 
 import immersive_aircraft.Main;
 import immersive_aircraft.client.OverlayRenderer;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RenderGuiLayerEvent;
+import net.neoforged.neoforge.client.gui.VanillaGuiLayers;
 
 @SuppressWarnings("unused")
 @EventBusSubscriber(modid = Main.MOD_ID, value = Dist.CLIENT)
 public class NeoForgeOverlayRenderer {
-    private static final ResourceLocation NamedGuiIdentifier = ResourceLocation.withDefaultNamespace("hotbar");
-
     @SubscribeEvent()
     public static void renderOverlay(RenderGuiLayerEvent.Post event) {
-        if (event.getName().equals(NamedGuiIdentifier)) {
+        if (event.getName() == VanillaGuiLayers.HOTBAR && !Minecraft.getInstance().options.hideGui) {
             OverlayRenderer.renderOverlay(event.getGuiGraphics(), event.getPartialTick().getGameTimeDeltaTicks());
         }
     }


### PR DESCRIPTION
This fixes the issue of the hotbar overlay still rendering after pressing F1 to hide the HUD on NeoForge. This may also fix #225? I haven't tested with Auto HUD.