### PR TITLE
Fix bug with infinite explosion and discard vehicle cycle 

### DIFF
--- a/common/src/main/java/immersive_aircraft/entity/VehicleEntity.java
+++ b/common/src/main/java/immersive_aircraft/entity/VehicleEntity.java
@@ -261,14 +261,10 @@ public abstract class VehicleEntity extends Entity {
         float health = getHealth() - amount;
         if (health <= 0) {
             setHealth(0);
-
-            // Explode if destroyed by force
-            if (force && canExplodeOnCrash && Config.getInstance().enableCrashExplosion) {
-                level().explode(this, getX(), getY(), getZ(),
-                        Config.getInstance().crashExplosionRadius,
-                        Config.getInstance().enableCrashFire,
-                        Config.getInstance().enableCrashBlockDestruction ? Level.ExplosionInteraction.MOB : Level.ExplosionInteraction.NONE);
-            }
+            // Saving cords for explode (if enabled)
+            double x = getX();
+            double y = getY();
+            double z = getZ();
 
             // Drop stuff if enabled
             if (level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS) && Config.getInstance().enableDropsForNonPlayer) {
@@ -277,6 +273,14 @@ public abstract class VehicleEntity extends Entity {
             }
 
             discard();
+
+            // Explode if destroyed by force
+            if (force && canExplodeOnCrash && Config.getInstance().enableCrashExplosion) {
+                level().explode(this, x, y, z,
+                        Config.getInstance().crashExplosionRadius,
+                        Config.getInstance().enableCrashFire,
+                        Config.getInstance().enableCrashBlockDestruction ? Level.ExplosionInteraction.MOB : Level.ExplosionInteraction.NONE);
+            }
         } else {
             setHealth(health);
         }


### PR DESCRIPTION
Fix bug with explosion and discard cycle

To reproduce: 
1. Enable crash explosion in config
2. Spawn 2 vehicles nearby (and damage them to 1-5 % for best result)
3. In survival try destroy one of vehicles with bow/other weapon
4. Server closes with huge crash report!

May be my fix isn't ideal, but I don't know better fix method 