### PR TITLE
Include model ID in non-quad face warning

### DIFF
--- a/common/src/main/java/immersive_aircraft/resources/bbmodel/BBMesh.java
+++ b/common/src/main/java/immersive_aircraft/resources/bbmodel/BBMesh.java
@@ -73,7 +73,7 @@ public class BBMesh extends BBObject implements BBFaceContainer {
                 }
 
                 if (vertexIdentifiers.size() != 4) {
-                    Main.LOGGER.warn("Face found, which is not a quad.");
+                    Main.LOGGER.warn("Non-quad face found in model: {}!", model.id);
                 } else {
                     // Get normal vector
                     float[] n = getNormal(vertexIdentifiers, positions);

--- a/common/src/main/java/immersive_aircraft/resources/bbmodel/BBModel.java
+++ b/common/src/main/java/immersive_aircraft/resources/bbmodel/BBModel.java
@@ -18,12 +18,14 @@ public class BBModel {
     public final HashMap<String, BBObject> objectsByName;
     public final List<BBAnimation> animations = new LinkedList<>();
     public final float textureWidth, textureHeight;
+    public final ResourceLocation id;
 
     public BBModel(JsonObject model, ResourceLocation identifier) {
         this.meta = new BBMeta(model.get("meta"));
         this.root = new LinkedList<>();
         this.objects = new HashMap<>();
         this.objectsByName = new HashMap<>();
+        this.id = identifier;
 
         JsonObject resolution = model.get("resolution").getAsJsonObject();
         this.textureWidth = resolution.getAsJsonPrimitive("width").getAsFloat();


### PR DESCRIPTION
This should make it much easier for addon devs to figure out what models contain non-quads.