### PR TITLE
Hide Aircraft HUD when using F1 while flying a plane

### DIFF
--- a/common/src/main/java/immersive_aircraft/client/OverlayRenderer.java
+++ b/common/src/main/java/immersive_aircraft/client/OverlayRenderer.java
@@ -37,6 +37,7 @@ public class OverlayRenderer {
 
     public static int renderOverlay(GuiGraphics context, float tickDelta, int barHeightOffset) {
         Minecraft client = Minecraft.getInstance();
+        if (client.options.hideGui) return 0;
         if (client.gameMode != null && client.player != null) {
             INSTANCE.tick = (INSTANCE.tick + 1) % 60;
 


### PR DESCRIPTION
Vanilla Minecraft has the entire HUD hidden when F1 is pressed. 
Immersive Aircraft doesn't hide its HUD elements like the aircraft health, speed and gyroscope UIs.

This is a very simple one line PR that adds a check for Minecraft's GUI being hidden when deciding whether to render the aircraft HUD in `OverlayRenderer`.

### Before
<img width="2107" height="1138" alt="image" src="https://github.com/user-attachments/assets/ff995094-1439-491f-af77-dd48ab4a4850" />

### After
<img width="1103" height="741" alt="no-hud" src="https://github.com/user-attachments/assets/8f8d125e-1c07-45d9-9185-15835e12e32e" />

